### PR TITLE
feat: Add search API configuration support and fix Elasticsearch clie…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stage0_py_utils"
-version = "0.2.5"
+version = "0.2.6"
 description = "A utility package for stage0 microservices"
 authors = [{name = "Mike Storey", email = "devs@agile-learning.institute"}]
 license = {text = "MIT"}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="stage0_py_utils",
-    version="0.2.5",
+    version="0.2.6",
     description="A utility package for stage0 microservices",
     author="Mike Storey",
     author_email="devs@agile-learning.institute",

--- a/stage0_py_utils/config/config.py
+++ b/stage0_py_utils/config/config.py
@@ -101,7 +101,7 @@ class Config:
                 "DISCORD_FRAN_TOKEN": ""
             }
             self.config_json_secrets = {
-                "ELASTIC_CLIENT_OPTIONS": '{"node":"http://localhost:9200"}',
+                "ELASTIC_CLIENT_OPTIONS": '{"hosts":"http://localhost:9200"}',
                 "ELASTIC_SEARCH_MAPPING": '{"properties":{"collection_name":{"type":"keyword"},"collection_id":{"type":"keyword"},"last_saved":{"type":"date"}}}',
                 "ELASTIC_SYNC_MAPPING": '{"properties":{"started_at":{"type":"date"}}}',
             }


### PR DESCRIPTION
…nt options

- Increment version to 0.2.6
- Add search API specific configuration items:
  - ELASTIC_SEARCH_INDEX
  - ELASTIC_SYNC_INDEX
  - ELASTIC_SEARCH_MAPPING
  - ELASTIC_SYNC_MAPPING
  - ELASTIC_SYNC_PERIOD
  - SYNC_BATCH_SIZE
- Fix ELASTIC_CLIENT_OPTIONS to use 'hosts' instead of 'node'
- All config tests passing