### PR TITLE
feat: Add MONGO_COLLECTION_NAMES config array

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="stage0_py_utils",
-    version="0.2.6",
+    version="0.2.7",
     description="A utility package for stage0 microservices",
     author="Mike Storey",
     author_email="devs@agile-learning.institute",

--- a/stage0_py_utils/config/config.py
+++ b/stage0_py_utils/config/config.py
@@ -56,6 +56,7 @@ class Config:
             self.ELASTIC_SYNC_MAPPING = {}
             self.ELASTIC_SYNC_PERIOD = 0
             self.SYNC_BATCH_SIZE = 0
+            self.MONGO_COLLECTION_NAMES = []
     
             # Default Values grouped by value type            
             self.config_strings = {
@@ -140,6 +141,16 @@ class Config:
         for key, default in self.config_json_secrets.items():
             value = json.loads(self._get_config_value(key, default, True))
             setattr(self, key, value)
+            
+        # Populate MONGO_COLLECTION_NAMES with all Mongo collection names
+        self.MONGO_COLLECTION_NAMES = [
+            self.BOT_COLLECTION_NAME,
+            self.CHAIN_COLLECTION_NAME,
+            self.CONVERSATION_COLLECTION_NAME,
+            self.WORKSHOP_COLLECTION_NAME,
+            self.EXERCISE_COLLECTION_NAME,
+            self.VERSION_COLLECTION_NAME
+        ]
             
         return
 

--- a/tests/config/test_mongo_collection_names.py
+++ b/tests/config/test_mongo_collection_names.py
@@ -1,0 +1,57 @@
+import unittest
+from stage0_py_utils import Config
+
+class TestMongoCollectionNames(unittest.TestCase):
+
+    def setUp(self):
+        """Re-initialize the config for each test."""
+        self.config = Config.get_instance()
+        self.config.initialize()
+
+    def test_mongo_collection_names_is_list(self):
+        """Test that MONGO_COLLECTION_NAMES is a list."""
+        self.assertIsInstance(self.config.MONGO_COLLECTION_NAMES, list)
+
+    def test_mongo_collection_names_contains_all_collections(self):
+        """Test that MONGO_COLLECTION_NAMES contains all expected collection names."""
+        expected_collections = [
+            self.config.BOT_COLLECTION_NAME,
+            self.config.CHAIN_COLLECTION_NAME,
+            self.config.CONVERSATION_COLLECTION_NAME,
+            self.config.WORKSHOP_COLLECTION_NAME,
+            self.config.EXERCISE_COLLECTION_NAME,
+            self.config.VERSION_COLLECTION_NAME
+        ]
+        
+        self.assertEqual(self.config.MONGO_COLLECTION_NAMES, expected_collections)
+
+    def test_mongo_collection_names_contains_default_values(self):
+        """Test that MONGO_COLLECTION_NAMES contains the default collection names."""
+        expected_defaults = [
+            "bots",
+            "chains", 
+            "conversations",
+            "workshops",
+            "exercises",
+            "CollectionVersions"
+        ]
+        
+        self.assertEqual(self.config.MONGO_COLLECTION_NAMES, expected_defaults)
+
+    def test_mongo_collection_names_no_duplicates(self):
+        """Test that MONGO_COLLECTION_NAMES contains no duplicate values."""
+        collection_names = self.config.MONGO_COLLECTION_NAMES
+        unique_names = list(set(collection_names))
+        self.assertEqual(len(collection_names), len(unique_names))
+
+    def test_mongo_collection_names_not_empty(self):
+        """Test that MONGO_COLLECTION_NAMES is not empty."""
+        self.assertGreater(len(self.config.MONGO_COLLECTION_NAMES), 0)
+
+    def test_mongo_collection_names_all_strings(self):
+        """Test that all values in MONGO_COLLECTION_NAMES are strings."""
+        for collection_name in self.config.MONGO_COLLECTION_NAMES:
+            self.assertIsInstance(collection_name, str)
+
+if __name__ == '__main__':
+    unittest.main() 


### PR DESCRIPTION
- Added MONGO_COLLECTION_NAMES instance variable to Config class
- Populated array with all Mongo collection names after initialization
- Added comprehensive unit tests for the new functionality
- Updated version to 0.2.7

The MONGO_COLLECTION_NAMES array contains:
- BOT_COLLECTION_NAME
- CHAIN_COLLECTION_NAME
- CONVERSATION_COLLECTION_NAME
- WORKSHOP_COLLECTION_NAME
- EXERCISE_COLLECTION_NAME
- VERSION_COLLECTION_NAME

All 186 tests passing.