### PR TITLE
feat: add ENUMERATORS_COLLECTION_NAME configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stage0_py_utils"
-version = "0.2.13"
+version = "0.2.14"
 description = "A utility package for stage0 microservices"
 authors = [{name = "Mike Storey", email = "devs@agile-learning.institute"}]
 license = {text = "MIT"}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="stage0_py_utils",
-    version="0.2.13",
+    version="0.2.14",
     description="A utility package for stage0 microservices",
     author="Mike Storey",
     author_email="devs@agile-learning.institute",

--- a/stage0_py_utils/config/config.py
+++ b/stage0_py_utils/config/config.py
@@ -38,6 +38,7 @@ class Config:
             self.BOT_COLLECTION_NAME = ''
             self.CHAIN_COLLECTION_NAME = ''
             self.CONVERSATION_COLLECTION_NAME = ''
+            self.ENUMERATORS_COLLECTION_NAME = ''
             self.EXECUTION_COLLECTION_NAME = ''
             self.EXERCISE_COLLECTION_NAME = ''
             self.RUNBOOK_COLLECTION_NAME = ''
@@ -91,6 +92,7 @@ class Config:
                 "BOT_COLLECTION_NAME": "bot",
                 "CHAIN_COLLECTION_NAME": "chain",
                 "CONVERSATION_COLLECTION_NAME": "conversation",
+                "ENUMERATORS_COLLECTION_NAME": "enumerators",
                 "EXECUTION_COLLECTION_NAME": "execution",
                 "EXERCISE_COLLECTION_NAME": "exercise",
                 "RUNBOOK_COLLECTION_NAME": "runbook",

--- a/tests/test_data/config/ENUMERATORS_COLLECTION_NAME
+++ b/tests/test_data/config/ENUMERATORS_COLLECTION_NAME
@@ -1,0 +1,1 @@
+TEST_VALUE 


### PR DESCRIPTION
- Add ENUMERATORS_COLLECTION_NAME as system collection with default 'enumerators'
- Add test configuration file for ENUMERATORS_COLLECTION_NAME
- Update tests to exclude enumerators from MONGO_COLLECTION_NAMES (system collection)
- Bump patch version from 0.2.13 to 0.2.14

The enumerators collection is treated as a system collection similar to VERSION_COLLECTION_NAME, providing configuration but not included in user-facing MongoDB collections list.

Closes #31 